### PR TITLE
Fix descriptions not using translatable text

### DIFF
--- a/src/main/resources/data/bowbattle/games/nether.json
+++ b/src/main/resources/data/bowbattle/games/nether.json
@@ -2,7 +2,9 @@
   "type": "bowbattle:bowbattle",
   "name": "Bow Battle Nether",
   "icon": "minecraft:bow",
-  "description": "game.bowbattle.standard.desc",
+  "description": {
+    "translate": "gameType.bowbattle.bowbattle.desc"
+  },
   "map": {
     "id": "bowbattle:nether"
   },

--- a/src/main/resources/data/bowbattle/games/standard.json
+++ b/src/main/resources/data/bowbattle/games/standard.json
@@ -2,7 +2,9 @@
   "type": "bowbattle:bowbattle",
   "name": "Bow Battle Standard",
   "icon": "minecraft:bow",
-  "description": "game.bowbattle.standard.desc",
+  "description": {
+    "translate": "gameType.bowbattle.bowbattle.desc"
+  },
   "map": {
     "id": "bowbattle:standard"
   },

--- a/src/main/resources/data/bowbattle/lang/en_us.json
+++ b/src/main/resources/data/bowbattle/lang/en_us.json
@@ -1,4 +1,4 @@
 {
   "gameType.bowbattle.bowbattle": "Bow Battle",
-  "game.bowbattle.standard.desc": "Bow Battle is a fast-paced free-for-all shootout."
+  "gameType.bowbattle.bowbattle.desc": "A fast-paced free-for-all shootout."
 }


### PR DESCRIPTION
<img width="730" alt="Game waiting lobby sidebar with description reading 'A fast-paced free-for-all shootout.'" src="https://github.com/user-attachments/assets/1a1eb234-a421-4721-ad1e-acea21cbff71">

Fixes #3